### PR TITLE
No longer auto-running uploadArchives task in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ allprojects {
     }
 }
 
-
 if (JavaVersion.current().isJava8Compatible()) {
     allprojects {
         tasks.withType(Javadoc) {
@@ -29,10 +28,11 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
 }
 
-
 android {
     compileSdkVersion 22
     buildToolsVersion "22.0.1"
+
+    // squelching errors from msa
     android {
         lintOptions {
             abortOnError false

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ if (JavaVersion.current().isJava8Compatible()) {
 android {
     compileSdkVersion 22
     buildToolsVersion "22.0.1"
+    android {
+        lintOptions {
+            abortOnError false
+        }
+    }
 
     defaultConfig {
         minSdkVersion 15
@@ -50,11 +55,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    //compile 'com.android.support:appcompat-v7:22.2.0'
 }
 
 
-uploadArchives {
+uploadArchives << {
     configuration = configurations.archives
     repositories.mavenDeployer {
         pom {


### PR DESCRIPTION
This change
- Suppresses lint errors from `stderr` and `stdout` (instead written to: `/build/outputs/lint-results.html` and  `/build/outputs/lint-results.xml`
- No longer runs the `task` `uploadArchives` by default as part of the `Maven plugin`

To run the upload task you can now...

```
$ gradle clean uploadArchives
```
