### PR TITLE
Remove uneeded onRecievedSSLError(...) override

### DIFF
--- a/src/main/java/com/microsoft/services/msa/AuthorizationRequest.java
+++ b/src/main/java/com/microsoft/services/msa/AuthorizationRequest.java
@@ -40,7 +40,6 @@ import android.content.DialogInterface.OnCancelListener;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.net.Uri;
-import android.net.http.SslError;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -48,7 +47,6 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
-import android.webkit.SslErrorHandler;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -134,13 +132,6 @@ class AuthorizationRequest implements ObservableOAuthRequest, OAuthRequestObserv
                                         String failingUrl) {
                 AuthorizationRequest.this.onError("", description, failingUrl);
                 OAuthDialog.this.dismiss();
-            }
-
-            @Override
-            public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-                // TODO: Android does not like the SSL certificate we use, because it has '*' in
-                // it. Proceed with the errors.
-                handler.proceed();
             }
 
             private void saveCookiesInMemory(String cookie) {


### PR DESCRIPTION
I received a report that google is detecting misuses of the onRecievedSSLErrors override and asking that application authors patch their applications.  Making sure we are not propagating this issue.
