### PR TITLE
Added switch to force prompt on login after logout

### DIFF
--- a/src/main/java/com/microsoft/services/msa/LiveAuthClient.java
+++ b/src/main/java/com/microsoft/services/msa/LiveAuthClient.java
@@ -495,22 +495,6 @@ public class LiveAuthClient {
      * @param listener called on either completion or error during the logout process.
      */
     public void logout(Object userState, LiveAuthListener listener) {
-        this.logout(userState, listener, false);
-    }
-    
-    /**
-     * Logs out the given user.
-     *
-     * Also, this method clears the previously created {@link LiveConnectSession}.
-     * {@link LiveAuthListener#onAuthComplete(LiveStatus, LiveConnectSession, Object)} will be
-     * called on completion. Otherwise,
-     * {@link LiveAuthListener#onAuthError(LiveAuthException, Object)} will be called.
-     *
-     * @param userState arbitrary object that is used to determine the caller of the method.
-     * @param listener called on either completion or error during the logout process.
-     * @param dropCookies pass true to force the user to enter his credentials (again) on login
-     */
-    public void logout(Object userState, LiveAuthListener listener, boolean dropCookies) {
         if (listener == null) {
             listener = NULL_LISTENER;
         }
@@ -527,29 +511,11 @@ public class LiveAuthClient {
                 CookieSyncManager.createInstance(this.applicationContext);
         CookieManager manager = CookieManager.getInstance();
         
-        if (dropCookies) {
-            // clear cookies to force prompt on login
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                manager.removeAllCookies(null);
-            else
-                manager.removeAllCookie();
-        } else {
-            final Uri logoutUri = mOAuthConfig.getLogoutUri();
-            String url = logoutUri.toString();
-            String domain = logoutUri.getHost();
-    
-            List<String> cookieKeys = this.getCookieKeysFromPreferences();
-            for (String cookieKey : cookieKeys) {
-                String value = TextUtils.join("", new String[] {
-                   cookieKey,
-                   "=; expires=Thu, 30-Oct-1980 16:00:00 GMT;domain=",
-                   domain,
-                   ";path=/;version=1"
-                });
-    
-                manager.setCookie(url, value);
-            }
-        }
+        // clear cookies to force prompt on login
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            manager.removeAllCookies(null);
+        else
+            manager.removeAllCookie();
 
         cookieSyncManager.sync();
         listener.onAuthComplete(LiveStatus.UNKNOWN, null, userState);

--- a/src/main/java/com/microsoft/services/msa/LiveAuthClient.java
+++ b/src/main/java/com/microsoft/services/msa/LiveAuthClient.java
@@ -494,7 +494,22 @@ public class LiveAuthClient {
      * @param listener called on either completion or error during the logout process.
      */
     public void logout(Object userState, LiveAuthListener listener) {
-
+        this(userState, listener, false);
+    }
+    
+    /**
+     * Logs out the given user.
+     *
+     * Also, this method clears the previously created {@link LiveConnectSession}.
+     * {@link LiveAuthListener#onAuthComplete(LiveStatus, LiveConnectSession, Object)} will be
+     * called on completion. Otherwise,
+     * {@link LiveAuthListener#onAuthError(LiveAuthException, Object)} will be called.
+     *
+     * @param userState arbitrary object that is used to determine the caller of the method.
+     * @param listener called on either completion or error during the logout process.
+     * @param dropCookies pass true to force the user to enter his credentials (again) on login
+     */
+    public void logout(Object userState, LiveAuthListener listener, boolean dropCookies) {
         if (listener == null) {
             listener = NULL_LISTENER;
         }
@@ -510,20 +525,29 @@ public class LiveAuthClient {
         CookieSyncManager cookieSyncManager =
                 CookieSyncManager.createInstance(this.applicationContext);
         CookieManager manager = CookieManager.getInstance();
-        final Uri logoutUri = mOAuthConfig.getLogoutUri();
-        String url = logoutUri.toString();
-        String domain = logoutUri.getHost();
-
-        List<String> cookieKeys = this.getCookieKeysFromPreferences();
-        for (String cookieKey : cookieKeys) {
-            String value = TextUtils.join("", new String[] {
-               cookieKey,
-               "=; expires=Thu, 30-Oct-1980 16:00:00 GMT;domain=",
-               domain,
-               ";path=/;version=1"
-            });
-
-            manager.setCookie(url, value);
+        
+        if (dropCookies) {
+            // clear cookies to force prompt on login
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+                manager.removeAllCookies(null);
+            else
+                manager.removeAllCookie();
+        } else {
+            final Uri logoutUri = mOAuthConfig.getLogoutUri();
+            String url = logoutUri.toString();
+            String domain = logoutUri.getHost();
+    
+            List<String> cookieKeys = this.getCookieKeysFromPreferences();
+            for (String cookieKey : cookieKeys) {
+                String value = TextUtils.join("", new String[] {
+                   cookieKey,
+                   "=; expires=Thu, 30-Oct-1980 16:00:00 GMT;domain=",
+                   domain,
+                   ";path=/;version=1"
+                });
+    
+                manager.setCookie(url, value);
+            }
         }
 
         cookieSyncManager.sync();

--- a/src/main/java/com/microsoft/services/msa/LiveAuthClient.java
+++ b/src/main/java/com/microsoft/services/msa/LiveAuthClient.java
@@ -28,6 +28,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.net.Uri;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.CookieManager;
@@ -494,7 +495,7 @@ public class LiveAuthClient {
      * @param listener called on either completion or error during the logout process.
      */
     public void logout(Object userState, LiveAuthListener listener) {
-        this(userState, listener, false);
+        this.logout(userState, listener, false);
     }
     
     /**


### PR DESCRIPTION
If a user signed out using logout() there was no way to sign in as another user as when using calling login() again the same user would be silently logged in again.
Now there's a switch to drop all cookies and force the user to pass his credentials on login() (again).

---

I found it better to put in `if (dropCookies)` (and check that first) instead of having it the other way around `if (! dropCookies)` as _imho_ negations are harder to read. We could, though, iverse this by calling it `keepCredentials` instead.

**If there's another way to force the prompt again please let me know. Maybe any of these changes aren't actually required as I just didn't look deep enough.**
