### PR TITLE
Dropped allowBackup from lib's manifest

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.microsoft.services.msa">
 
-    <application android:allowBackup="true" android:label="@string/app_name">
-
-    </application>
+    <application android:label="@string/app_name" />
 
 </manifest>


### PR DESCRIPTION
Dropped the attribute allowBackup from the lib's manifest (application) as it's implicitly true already and may force users to override it.
