### PR TITLE
Lower the Android Min Version to 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 10
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
The previously released LiveSDK for Android required a min version of 10,
there are not hard requirements in this library for version 14, so making
the bump
